### PR TITLE
Fixed package version & configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
 
 install:
   - pip install ansible==2.3.0.0
-  - sudo apt-get remove -y --purge elasticsearch openjdk-7-jre openjdk-7-jdk
-  - sudo dpkg -l | grep openjdk
-  - sudo apt-get install -y -qq openjdk-8-jre
+  - sudo apt-get remove -y --purge elasticsearch
+  - sudo apt-get install -y -qq openjdk-8-jdk
+  - sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
 
 script:
   - java -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 install:
   - pip install ansible==2.3.0.0
   - sudo apt-get remove -y --purge elasticsearch openjdk-7-jre openjdk-7-jdk
+  - sudo dpkg -l | grep openjdk
   - sudo apt-get install -y -qq openjdk-8-jre
 
 script:

--- a/README.md
+++ b/README.md
@@ -9,18 +9,68 @@ through the official repositories
 
   * EL / Centos (6 / 7)
   * Debian (Jessie)
-  * Ubuntu (Trusty)
+  * Ubuntu (Trusty / Xenial)
   * AMZ Linux
 
 ## Role Variables
 
-FIXME
+The following role variables are defined in `defaults/main.yml`. For a
+detailed explanation about them you can take a look at the file.
+
+```
+es_version: 5.5.0
+
+es_cfg_cluster_name: elasticsearch
+es_cfg_node_master:  'true'
+es_cfg_node_data:    'true'
+es_cfg_log_dir: /var/log/elasticsearch
+es_cfg_path_data:
+  - /var/lib/elasticsearch
+ 
+es_config_default:
+  cluster.name: {{es_cfg_cluster_name}}
+  node.master:  {{es_cfg_node_master}}
+  node.data:    {{es_cfg_node_data}}
+
+  path.logs: {{es_cfg_log_dir}}
+  path.data: "{{es_cfg_path_data}}"
+
+es_config: "{{es_config_default}}"
+```
+
+### JVM settings
+
+The defaults for the JVM config (`jvm.config`) are based on elasticsearch
+defaults, and are defined through the variable `es_config_jvm_defaults`:
+
+```
+es_jvm_mem: 2g
+
+es_config_jvm_defaults: |
+  -Xms{{es_jvm_mem}}
+  -Xmx{{es_jvm_mem}}
+  -XX:+UseConcMarkSweepGC
+  -XX:CMSInitiatingOccupancyFraction=75
+  -XX:+UseCMSInitiatingOccupancyOnly
+  -XX:+AlwaysPreTouch
+  -server
+  -Xss1m
+  -Djava.awt.headless=true
+  -Dfile.encoding=UTF-8
+  -Djna.nosys=true
+  -Djdk.io.permissionsUseCanonicalPath=true
+  -Dio.netty.noUnsafe=true
+  -Dio.netty.noKeySetOptimization=true
+  -Dio.netty.recycler.maxCapacityPerThread=0
+  -Dlog4j.shutdownHookEnabled=false
+  -Dlog4j2.disable.jmx=true
+  -Dlog4j.skipJansi=true
+  -XX:+HeapDumpOnOutOfMemoryError
+
+es_config_jvm: "{{es_config_jvm_defaults}}"
+```
 
 ## Usage
-
-FIXME
-
-## TODO
 
 FIXME
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider :virtualbox do |vb|
     vb.gui = false
-    vb.customize [ 'modifyvm', :id, '--memory', '512' ]
+    vb.customize [ 'modifyvm', :id, '--memory', '1024' ]
     vb.customize [ 'modifyvm', :id, '--nictype1', 'virtio' ]
     vb.customize [ 'modifyvm', :id, '--natdnshostresolver1', 'on' ]
     vb.customize [ 'modifyvm', :id, '--natdnsproxy1', 'on' ]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,12 +8,13 @@ es_group: elasticsearch
 
 # ElasticSearch version to use
 # 
-es_version: 5.x
+es_version: 5.5.0
+es_version_repo: "{{es_version|regex_replace('^([0-9]+)\\..*$', '\\1')}}.x"
 
 es_gpg_key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
 
 es_baseurl: "https://artifacts.elastic.co"
-es_repo_baseurl: "{{es_baseurl}}/packages/{{es_version}}"
+es_repo_baseurl: "{{es_baseurl}}/packages/{{es_version_repo}}"
 es_package_baseurl: "{{es_baseurl}}/downloads/elasticsearch"
 
 es_use_repo: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,7 @@ es_upgrade: false
 
 # Installation directory
 es_install_dir: /usr/share/elasticsearch
-es_config_dir:    /etc/elasticsearch
+es_config_dir:  /etc/elasticsearch
 
 
 # ElasticSearch JVM config
@@ -72,10 +72,8 @@ es_plugins: []
 # Some defaults
 #
 es_cfg_cluster_name: elasticsearch
-es_cfg_node_master: 'true'
-es_cfg_node_data: 'true'
-es_cfg_index_number_of_shards:   5
-es_cfg_index_number_of_replicas: 1
+es_cfg_node_master: true
+es_cfg_node_data: true
 es_cfg_log_dir: /var/log/elasticsearch
 es_cfg_path_data:
   - /var/lib/elasticsearch
@@ -83,16 +81,13 @@ es_cfg_path_data:
 
 # ElasticSearch default configuration
 #
-es_config_default: |
-  cluster.name: {{es_cfg_cluster_name}}
-  node.master:  {{es_cfg_node_master}}
-  node.data:    {{es_cfg_node_data}}
+es_config_default:
+  cluster.name: "{{es_cfg_cluster_name}}"
+  node.master:  "{{es_cfg_node_master}}"
+  node.data:    "{{es_cfg_node_data}}"
 
-  index.number_of_shards:   {{es_cfg_index_number_of_shards}}
-  index.number_of_replicas: {{es_cfg_index_number_of_replicas}}
-
-  path.logs: {{es_cfg_log_dir}}
-  path.data: {{es_cfg_path_data}}
+  path.logs: "{{es_cfg_log_dir}}"
+  path.data: "{{es_cfg_path_data}}"
 
 
 # ElasticSearch configuration

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -19,12 +19,16 @@
   notify: elasticsearch restart
 
 - name: elasticsearch.yml
-  template:
-    src:   etc/elasticsearch/elasticsearch.yml.j2
-    dest:  /etc/elasticsearch/elasticsearch.yml
-    owner: "root"
-    group: "root"
-    mode:  "0644"
+  copy:
+    dest:    /etc/elasticsearch/elasticsearch.yml
+    owner:   "root"
+    group:   "root"
+    mode:    "0644"
+    content: |
+      # << Ansible managed file >>
+      
+      {{es_config|to_nice_yaml(indent=2)}}
+      
   notify: elasticsearch restart
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,4 +6,11 @@
 - include: install/RedHat.yml
   when: ansible_os_family == 'RedHat'
 
+- name: Install Elasticsearch
+  package:
+    state: "{{ (es_upgrade) | ternary('latest', 'present') }}"
+    name:  "{{es_package}}"
+  notify: elasticsearch restart
+  when: es_use_repo
+
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -4,18 +4,28 @@
   apt_key:
     state: present
     url: "{{es_gpg_key}}"
+  when: es_use_repo
 
 - name: ElasticSearch APT Repository
   apt_repository:
     state: present
     repo: "deb {{es_apt_repository}} stable main"
     update_cache: true
+  when: es_use_repo
 
-- name: Install ElasticSearch (Debian)
-  apt:
-    state: "{{ (es_upgrade) | ternary('latest', 'present') }}"
-    name: "{{item}}"
-  with_items: "{{es_packages}}"
-  notify: elasticsearch restart
+- block:
+
+  - name: Download ElasticSearch DEB
+    get_url:
+      url: "{{es_package_url}}"
+      dest: "/var/cache/apt/archives/elasticsearch-{{es_version}}.deb"
+
+  - name: Install ElasticSearch from DEB
+    apt:
+      deb: "/var/cache/apt/archives/elasticsearch-{{es_version}}.deb"
+      state: present
+    notify: elasticsearch restart
+
+  when: not es_use_repo
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/install/RedHat.yml
+++ b/tasks/install/RedHat.yml
@@ -9,28 +9,19 @@
     mode: "0644"
   when: es_use_repo
 
-- name: Install ElasticSearch (RedHat)
-  yum:
-    state: "{{ (es_upgrade) | ternary('latest', 'present') }}"
-    name: "{{item}}"
-    update_cache: yes
-  with_items: "{{es_packages}}"
-  notify: elasticsearch restart
-  when: es_use_repo
+- block:
 
-- name: Download ElasticSearch RPM
-  get_url:
-    url: "{{es_package_baseurl}}/{{item}}-{{es_version}}.rpm"
-    dest: "/var/cache/yum/{{ansible_architecture}}/{{item}}-{{es_version}}.rpm"
-  with_items: "{{es_packages}}"
-  when: not es_use_repo
+  - name: Download ElasticSearch RPM
+    get_url:
+      url: "{{es_package_url}}"
+      dest: "/var/cache/yum/{{ansible_architecture}}/elasticsearch-{{es_version}}.rpm"
 
-- name: Install ElasticSearch from RPM
-  yum:
-    name: "/var/cache/yum/{{ansible_architecture}}/{{item}}-{{es_version}}.rpm"
-    state: present
-  with_items: "{{es_packages}}"
-  notify: es restart
+  - name: Install ElasticSearch from RPM
+    yum:
+      name: "/var/cache/yum/{{ansible_architecture}}/elasticsearch-{{es_version}}.rpm"
+      state: present
+    notify: es restart
+
   when: not es_use_repo
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/templates/etc/elasticsearch/elasticsearch.yml.j2
+++ b/templates/etc/elasticsearch/elasticsearch.yml.j2
@@ -1,5 +1,0 @@
-# << Ansible managed file >>
-
-{{es_config}}
-
-# vi:ts=2:sw=2:et:ft=yaml

--- a/tests/test_defaults.yml
+++ b/tests/test_defaults.yml
@@ -4,7 +4,6 @@
   remote_user: root
 
   vars:
-    - es_version: 5.x
     - es_jvm_mem: 512m
 
   roles:

--- a/tests/test_plugins.yml
+++ b/tests/test_plugins.yml
@@ -3,10 +3,9 @@
   remote_user: root
 
   vars:
-    - es_version: 5.x
     - es_jvm_mem: 512m
     - es_plugins:
-        - ingest-geoip
+        - discovery-ec2
 
   roles:
     - { role: ansible-role-elasticsearch }

--- a/tests/test_vagrant.yml
+++ b/tests/test_vagrant.yml
@@ -6,8 +6,6 @@
 
   vars:
     - es_jvm_mem: 256m
-    - es_plugins:
-        - ingest-geoip
 
   roles:
     - { role: ansible-role-elasticsearch }
@@ -18,9 +16,8 @@
   become: true
 
   vars:
-    - es_version: 5.5.0
-    - es_jvm_mem: 256m
     - es_use_repo: false
+    - es_jvm_mem: 256m
 
   roles:
     - { role: ansible-role-elasticsearch }

--- a/tests/test_vagrant.yml
+++ b/tests/test_vagrant.yml
@@ -5,6 +5,7 @@
   become: true
 
   vars:
+    - es_jvm_mem: 256m
     - es_plugins:
         - ingest-geoip
 
@@ -18,6 +19,7 @@
 
   vars:
     - es_version: 5.5.0
+    - es_jvm_mem: 256m
     - es_use_repo: false
 
   roles:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,7 +3,8 @@
 es_apt_key: "{{es_gpg_key}}"
 es_apt_repository: "{{es_repo_baseurl}}/apt"
 
-es_packages:
-  - elasticsearch
+es_package: "elasticsearch={{es_version}}"
+
+es_package_url: "{{es_package_baseurl}}/elasticsearch-{{es_version}}.deb"
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -10,7 +10,8 @@ es_yum_config: |
   gpgkey={{es_gpg_key}}
   enabled=1
 
-es_packages:
-  - elasticsearch
+es_package: "elasticsearch-{{es_version}}-1"
+
+es_package_url: "{{es_package_baseurl}}/elasticsearch-{{es_version}}.rpm"
 
 # vi:ts=2:sw=2:et:ft=yaml


### PR DESCRIPTION
Version & Install from url
  * Fixed issue related to package version. Now the specified one is installed (as opposed to always installing the latest one)
  * Improved install from url (`es_use_repo: false`). Now uses a default `es_package_url` which can be overwritten

Configuration moved from block to yaml
  * Instead of having the `es_config` var be a string block, it is now a plain yaml var. 
     Should require minimal changes from: 
```
es_config: |
  cluster.name: ...
  # ...
```
to
```
es_config:
  cluster.name: ...
  # ...
```